### PR TITLE
Use Node 24

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup node 20
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - name: Setup node 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
       - run: npm install
       - run: npm run build
       - run: npm test

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
-      - name: Setup node 24
+      - name: Setup node
         uses: actions/setup-node@v6
         with:
           node-version: 24.x

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,9 @@ inputs:
     required: false
   sync-labels:
     description: 'Whether or not to remove labels when matching files are reverted'
-    default: false
+    default: 'false'
     required: false
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
GitHub will force using Node24 start from June 16th, 2026, See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/